### PR TITLE
Allow specifying feature key by env var

### DIFF
--- a/prism-image-search/README.md
+++ b/prism-image-search/README.md
@@ -65,14 +65,14 @@ ln -s ~/Pictures container-volumes/prism/images/static/data
 cd prism-image-search && \\
 docker build -t prism . -f Dockerfile-prism
 ```
-
 ### 2. Add features.conf
 AVS needs an Aerospike features.conf file with the vector-search feature enabled.
-Add your features.conf file to container-volumes/avs/etc/avs.
+You can set the `features.conf` location in an environment variable: `FEATURE_KEY' 
+or add your features.conf file to `container-volumes/avs/etc/aerospike-vector-search`
 
 ### 3. Start the environment
 ```
-docker compose -f docker-compose-dev.yml up
+FEATURE_KEY=/path/to/features.conf docker compose -f docker-compose-dev.yml up
 ```
 
 ## Developing

--- a/prism-image-search/README.md
+++ b/prism-image-search/README.md
@@ -67,8 +67,9 @@ docker build -t prism . -f Dockerfile-prism
 ```
 ### 2. Add features.conf
 AVS needs an Aerospike features.conf file with the vector-search feature enabled.
-You can set the `features.conf` location in an environment variable: `FEATURE_KEY' 
-or add your features.conf file to `container-volumes/avs/etc/aerospike-vector-search`
+Optionally set `FEATURE_KEY` environment variable with the location of your `features.conf` file.
+
+If no variable is set it will expect the features.conf to be in  `container-volumes/avs/etc/aerospike-vector-search`
 
 ### 3. Start the environment
 ```

--- a/prism-image-search/docker-compose-dev.yml
+++ b/prism-image-search/docker-compose-dev.yml
@@ -20,6 +20,8 @@ services:
       retries: 10
   avs:
     image: aerospike/aerospike-vector-search:0.10.0
+    environment:
+      FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"
     depends_on:
       aerospike:
         condition: service_healthy
@@ -27,13 +29,14 @@ services:
       - avs-demo
     volumes:
       - ./container-volumes/avs/etc/aerospike-vector-search:/etc/aerospike-vector-search
+      - ${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}:/etc/aerospike-vector-search/features.conf:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://avs:5040/manage/rest/v1"]
       interval: 5s
       timeout: 20s
       retries: 10
   app:
-    image: prism:latest
+    image: "prism:latest"
     depends_on: 
       avs:
         condition: service_healthy

--- a/prism-image-search/docker-compose.yml
+++ b/prism-image-search/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       retries: 10
   avs:
     image: aerospike/aerospike-vector-search:0.10.0
+    environment:
+      FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"
     depends_on:
       aerospike:
         condition: service_healthy
@@ -27,13 +29,14 @@ services:
       - avs-demo
     volumes:
       - ./container-volumes/avs/etc/aerospike-vector-search:/etc/aerospike-vector-search
+      - ${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}:/etc/aerospike-vector-search/features.conf:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://avs:5040/manage/rest/v1"]
       interval: 5s
       timeout: 20s
       retries: 10
   app:
-    image: aerospike/prism-search-example:latest
+    image: "aerospike/prism-search-example:latest"
     depends_on: 
       avs:
         condition: service_healthy

--- a/quote-semantic-search/README.md
+++ b/quote-semantic-search/README.md
@@ -57,8 +57,10 @@ docker build -t quote-search . -f Dockerfile-quote-search
 
 ### 2. Add features.conf
 AVS needs an Aerospike features.conf file with the vector-search feature enabled.
-You can set the `features.conf` location in an environment variable: `FEATURE_KEY' 
-or add your features.conf file to `container-volumes/avs/etc/aerospike-vector-search`
+Optionally set `FEATURE_KEY` environment variable with the location of your `features.conf` file.
+
+If no variable is set it will expect the features.conf to be in  `container-volumes/avs/etc/aerospike-vector-search`
+
 
 
 ### 3. Start the environment

--- a/quote-semantic-search/README.md
+++ b/quote-semantic-search/README.md
@@ -57,12 +57,14 @@ docker build -t quote-search . -f Dockerfile-quote-search
 
 ### 2. Add features.conf
 AVS needs an Aerospike features.conf file with the vector-search feature enabled.
-Add your features.conf file to container-volumes/avs/etc/aerospike-vector-search.
+You can set the `features.conf` location in an environment variable: `FEATURE_KEY' 
+or add your features.conf file to `container-volumes/avs/etc/aerospike-vector-search`
 
 
 ### 3. Start the environment
 ```
-docker compose -f docker-compose-dev.yml up
+FEATURE_KEY=/path/to/features.conf docker compose -f docker-compose-dev.yml up
+
 ```
 
 ## Developing

--- a/quote-semantic-search/docker-compose-dev.yml
+++ b/quote-semantic-search/docker-compose-dev.yml
@@ -19,23 +19,24 @@ services:
       timeout: 20s
       retries: 10
   avs:
+    image: aerospike/aerospike-vector-search:0.10.0
+    environment:
+      FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"
     depends_on:
       aerospike:
         condition: service_healthy
-    image: aerospike/aerospike-vector-search:0.10.0
-    # ports:
-    #   - "5002:5002"
     networks:
       - avs-demo
     volumes:
       - ./container-volumes/avs/etc/aerospike-vector-search:/etc/aerospike-vector-search
+      - ${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}:/etc/aerospike-vector-search/features.conf:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://avs:5040/manage/rest/v1"]
       interval: 5s
       timeout: 20s
       retries: 10
   app:
-    image: quote-search:latest
+    image: "quote-search:latest"
     depends_on:
       avs:
         condition: service_healthy

--- a/quote-semantic-search/docker-compose.yml
+++ b/quote-semantic-search/docker-compose.yml
@@ -19,23 +19,24 @@ services:
       timeout: 20s
       retries: 10
   avs:
+    image: aerospike/aerospike-vector-search:0.10.0
+    environment:
+      FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"
     depends_on:
       aerospike:
         condition: service_healthy
-    image: aerospike/aerospike-vector-search:0.10.0
-    # ports:
-    #   - "5002:5002"
     networks:
       - avs-demo
     volumes:
       - ./container-volumes/avs/etc/aerospike-vector-search:/etc/aerospike-vector-search
+      - ${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}:/etc/aerospike-vector-search/features.conf:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://avs:5040/manage/rest/v1"]
       interval: 5s
       timeout: 20s
       retries: 10
   app:
-    image: aerospike/quote-search-example:latest
+    image: "aerospike/quote-search-example:latest"
     depends_on:
       avs:
         condition: service_healthy


### PR DESCRIPTION
Allow specifying the feature key via environment variable when you run docker compose.

For example to use the one I have for aerospike already in /etc/aerospike/features.conf

`FEATURE_KEY=/etc/aerospike/features.conf  docker compose up`

If there is no FEATURE_KEY set it works as before (looking to the container-volumes)