### PR TITLE
Upgrade Python client to 3.0.1

### DIFF
--- a/basic-search/requirements.txt
+++ b/basic-search/requirements.txt
@@ -1,1 +1,1 @@
-aerospike-vector-search==3.0.0
+aerospike-vector-search==3.0.1

--- a/prism-image-search/prism/requirements.txt
+++ b/prism-image-search/prism/requirements.txt
@@ -1,6 +1,6 @@
 # TODO: Include exact versions
 # Aerospike dependencies
-aerospike-vector-search==3.0.0
+aerospike-vector-search==3.0.1
 
 # Flask framework
 flask~=2.3.2

--- a/quote-semantic-search/quote-search/requirements.txt
+++ b/quote-semantic-search/quote-search/requirements.txt
@@ -1,6 +1,6 @@
 # TODO: Include exact versions
 # Aerospike dependencies
-aerospike-vector-search==3.0.0
+aerospike-vector-search==3.0.1
 
 
 # Flask framework


### PR DESCRIPTION
I don't think we need to cut a new examples release for this, it can be included in whatever the next release is. Relates to vec-420