### PR TITLE
Update examples to use AVS v0.11.1 docker-image

### DIFF
--- a/kubernetes/full-create-and-install.sh
+++ b/kubernetes/full-create-and-install.sh
@@ -417,7 +417,7 @@ deploy_avs_helm_chart() {
     helm repo add aerospike-helm https://artifact.aerospike.io/artifactory/api/helm/aerospike-helm
     helm repo update
     if [ -z "$CHART_LOCATION" ]; then
-        helm install avs-gke --values $BUILD_DIR/manifests/avs-gke-values.yaml --namespace avs aerospike-helm/aerospike-vector-search --version 0.4.1 --wait
+        helm install avs-gke --values $BUILD_DIR/manifests/avs-gke-values.yaml --namespace avs aerospike-helm/aerospike-vector-search --version 0.6.0 --wait
     else
         helm install avs-gke --values $BUILD_DIR/manifests/avs-gke-values.yaml --namespace avs "$CHART_LOCATION" --wait
     fi


### PR DESCRIPTION
I see that examples are already updated to use  v0.11.1, just very small fix.