### PR TITLE
Rename 'avs' service to 'aerospike-vector-search' in docker-compose files

### DIFF
--- a/prism-image-search/docker-compose-asdb-6.4.yml
+++ b/prism-image-search/docker-compose-asdb-6.4.yml
@@ -18,7 +18,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 10
-  avs:
+  aerospike-vector-search:
     image: aerospike/aerospike-vector-search:1.0.0
     environment:
       FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"

--- a/prism-image-search/docker-compose-dev.yml
+++ b/prism-image-search/docker-compose-dev.yml
@@ -19,7 +19,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 10
-  avs:
+  aerospike-vector-search:
     image: aerospike/aerospike-vector-search:1.0.0
     environment:
       FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"

--- a/prism-image-search/docker-compose.yml
+++ b/prism-image-search/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 10
-  avs:
+  aerospike-vector-search:
     image: aerospike/aerospike-vector-search:1.0.0
     environment:
       FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"

--- a/quote-semantic-search/docker-compose-asdb-6.4.yml
+++ b/quote-semantic-search/docker-compose-asdb-6.4.yml
@@ -18,7 +18,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 10
-  avs:
+  aerospike-vector-search:
     image: aerospike/aerospike-vector-search:1.0.0
     environment:
       FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"

--- a/quote-semantic-search/docker-compose-dev.yml
+++ b/quote-semantic-search/docker-compose-dev.yml
@@ -18,7 +18,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 10
-  avs:
+  aerospike-vector-search:
     image: aerospike/aerospike-vector-search:1.0.0
     environment:
       FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"

--- a/quote-semantic-search/docker-compose.yml
+++ b/quote-semantic-search/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 10
-  avs:
+  aerospike-vector-search:
     image: aerospike/aerospike-vector-search:1.0.0
     environment:
       FEATURE_KEY: "${FEATURE_KEY:-./container-volumes/avs/etc/aerospike-vector-search/features.conf}"


### PR DESCRIPTION
Restore the correct service name for Aerospike vector search in the docker-compose configuration after it was lost in a previous merge.