### PR TITLE
Removes symlink from docker instructions for prism

### DIFF
--- a/prism-image-search/README.md
+++ b/prism-image-search/README.md
@@ -54,10 +54,11 @@ description.
 
 ## Install using docker compose
 If you have a license key, you can easily setup Aerospike, AVS, and the prism-image-search
-app using docker-compose. When using docker-compose, you'll need to place your images in `container-volumes/prism/images/static/data`
+app using docker-compose. When using docker-compose, you'll need to place your images in `container-volumes/prism/images/static/data`. 
+You can not use a sym link. This command will copy jpgs from your `~/Pictures` directory. 
 
 ```shell
-ln -s ~/Pictures container-volumes/prism/images/static/data
+rsync -av --include='*/' --include='*.jp*' --exclude='*' ~/Pictures ./aerospike-vector-search-examples/prism-image-search/container-volumes/prism/images/static/data
 ```
 
 ### 1. Build the prism image 


### PR DESCRIPTION
This sym link doesn't work. Replaced with an rsyc command.