### PR TITLE
Gke example integrated

### DIFF
--- a/kubernetes/manifests/aerospike-cr.yaml
+++ b/kubernetes/manifests/aerospike-cr.yaml
@@ -73,7 +73,7 @@ spec:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
           - matchExpressions:
-            - key: aerospike.com/node-pool
+            - key: aerospike.io/node-pool
               operator: In
               values:
               - "default-rack"

--- a/kubernetes/manifests/avs-values.yaml
+++ b/kubernetes/manifests/avs-values.yaml
@@ -41,11 +41,11 @@ aerospikeVectorSearchConfig:
     ticker-interval: 10
 
 aerospikeVectorSearchNodeRoles:
-  node-label-1:
+  node-label-0:
     - query
   node-label-2:
-    - query
     - index-update
+
 
 serviceAccount:
   create: true

--- a/kubernetes/manifests/avs-values.yaml
+++ b/kubernetes/manifests/avs-values.yaml
@@ -43,6 +43,8 @@ aerospikeVectorSearchConfig:
 aerospikeVectorSearchNodeRoles:
   node-label-0:
     - query
+  node-label-1:
+    - query
   node-label-2:
     - index-update
 
@@ -73,7 +75,7 @@ affinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: aerospike.com/node-pool
+          - key: aerospike.io/node-pool
             operator: In
             values:
             - "avs"


### PR DESCRIPTION
This allows internal releases to be used (in case of unreleased but packaged docker or helm charts as well as some naming and other fixes to work with current deploy scripts)