### PR TITLE
chore: update Aerospike image versions in manifests

### DIFF
--- a/kubernetes/manifests/aerospike-cr-auth.yaml
+++ b/kubernetes/manifests/aerospike-cr-auth.yaml
@@ -6,7 +6,7 @@ metadata:
 
 spec:
   size: 1
-  image: aerospike/aerospike-server-enterprise:8.0
+  image: aerospike/aerospike-server-enterprise:8.0.0.2
   storage:
     filesystemVolumePolicy:
       initMethod: deleteFiles

--- a/kubernetes/manifests/aerospike-cr.yaml
+++ b/kubernetes/manifests/aerospike-cr.yaml
@@ -6,7 +6,8 @@ metadata:
 
 spec:
   size: 1
-  image: aerospike/aerospike-server-enterprise:8.0
+  image: aerospike/aerospike-server-enterprise:8.0.0.2
+
   storage:
     filesystemVolumePolicy:
       initMethod: deleteFiles

--- a/kubernetes/manifests/avs-values-auth.yaml
+++ b/kubernetes/manifests/avs-values-auth.yaml
@@ -102,8 +102,7 @@ service:
 
 initContainer:
    image:
-     repository: aerospike.jfrog.io/container/avs-init-container:0.8.0
-     tag: "0.8.1"
+     repository: aerospike.jfrog.io/container/avs-init-container
      pullPolicy: Always
 
 image:

--- a/kubernetes/manifests/avs-values.yaml
+++ b/kubernetes/manifests/avs-values.yaml
@@ -66,15 +66,13 @@ service:
 
 initContainer:
    image:
-     repository: aerospike.jfrog.io/container/avs-init-container:0.8.0
-     tag: "0.8.1"
+     repository: aerospike.jfrog.io/container/avs-init-container
      pullPolicy: Always
 
 image:
   repository: "aerospike/aerospike-vector-search"
   pullPolicy: "IfNotPresent"
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.0.0"
+
 
 extraSecretVolumeMounts:
   - name: aerospike-tls


### PR DESCRIPTION
And simplify values to rely on defaults (update chart not every example)